### PR TITLE
WIP: Add `on-init` action

### DIFF
--- a/addon/components/x-xml-http-request.js
+++ b/addon/components/x-xml-http-request.js
@@ -197,5 +197,6 @@ export default Ember.Component.extend({
   didInsertElement(...args) {
     this._super(...args);
     this.setInitialState();
+    this.sendAction('on-init', this.get('model'));
   }
 });

--- a/tests/integration/components/x-xml-http-request-test.js
+++ b/tests/integration/components/x-xml-http-request-test.js
@@ -7,7 +7,7 @@ import hbs from 'htmlbars-inline-precompile';
 
 describeComponent(
   'x-xml-http-request',
-  'Integration: XXmlHttpRequestComponent',
+  'Integration: XmlHttpRequestComponent',
   {
     integration: true
   },
@@ -29,13 +29,19 @@ describeComponent(
       this.set('headers', {one: "two"});
       this.set('method', 'POST');
       this.set('data', {hello: 'I am data'});
+      this.set('onInit', sinon.spy());
       this.render(hbs`
-{{#x-xml-http-request headers=headers response-type="json" method="POST" url="http://google.com" with-credentials=true timeout=1200 request-constructor=XRequestStub as |xhr|}}
+{{#x-xml-http-request headers=headers on-init=onInit response-type="json" method="POST" url="http://google.com" with-credentials=true timeout=1200 request-constructor=XRequestStub as |xhr|}}
   <div class="spec-status {{if xhr.isLoadStarted 'load-started'}}">Status</div>
   <button class="spec-send" {{action (action xhr.send data)}}>Send</button>
   <button class="spec-abort" {{action xhr.abort}}>Abort</button>
   <button class="spec-reset" {{action xhr.reset}}>Reset</button>
 {{/x-xml-http-request}}`);
+    });
+
+    it("invokes the on-init action", function() {
+      expect(this.get('onInit').called).to.equal(true);
+      expect(this.get('onInit').firstCall).to.have.deep.property("args[0].send");
     });
 
     it('invokes the x-request constructor', function() {


### PR DESCRIPTION
Sometimes you want to start the an upload as soon as the component is
rendered, and so you need to fire the `send` action immediately without
waiting for further events initiated by the user.

To do this, we add the `on-init` action which receives the request model
as its argument, and so any of the actions can be invoked there.
### TODO
- [ ] Add docs for this new action.
- [ ] Should it be `on-request` instead? And fire every time there is a new request?
